### PR TITLE
🔧 chore(docker-compose): remove unnecessary DB_PORT environment varia…

### DIFF
--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -9,7 +9,6 @@ services:
       - GRPC_PORT=9200
       - HTTP_PORT=9201
       - DB_HOST=prod-postgre
-      - DB_PORT=5432
       - DB_USERNAME=postgres
       - DB_PASSWORD=123456
       - DB_NAME=store-service

--- a/docker-compose.staging.yaml
+++ b/docker-compose.staging.yaml
@@ -9,7 +9,6 @@ services:
       - GRPC_PORT=7200
       - HTTP_PORT=7201
       - DB_HOST=staging-postgre
-      - DB_PORT=5433
       - DB_USERNAME=postgres
       - DB_PASSWORD=123456
       - DB_NAME=store-service


### PR DESCRIPTION
…ble in prod and staging configurations

The DB_PORT environment variable is no longer needed in the prod and staging configurations as the default port for PostgreSQL (5432) is used. Removing this variable simplifies the configuration and reduces redundancy.