### PR TITLE
🐛 fix(service.go): set default opening and closing hours to "00:00" a…

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -75,6 +75,13 @@ func (s *service) CreateStore(ctx context.Context, store *entity.Store) (*entity
 		img.ImageURL = imageURL
 	}
 
+	for _, hour := range store.Hours {
+		if hour.Is24Hr {
+			hour.Open = "00:00"
+			hour.Close = "23:59"
+		}
+	}
+
 	return s.storeRepository.CreateStore(ctx, store)
 }
 
@@ -135,6 +142,11 @@ func (s *service) UpdateStore(ctx context.Context, storeID string, update *entit
 		hour.UpdatedBy = claims.UserID
 		hour.StoreID = update.ID
 		hour.ID = uuid.Nil
+
+		if hour.Is24Hr {
+			hour.Open = "00:00"
+			hour.Close = "23:59"
+		}
 	}
 
 	return s.storeRepository.UpdateStore(ctx, update)


### PR DESCRIPTION
…nd "23:59" respectively for stores with 24-hour operation

✨ feat(service.go): update CreateStore and UpdateStore functions to handle stores with 24-hour operation by setting default opening and closing hours to "00:00" and "23:59" respectively