### PR TITLE
🐛 fix(postgres.go): add deletion of products associated with stores t…

### DIFF
--- a/domain/store/repository/postgres/postgres.go
+++ b/domain/store/repository/postgres/postgres.go
@@ -176,6 +176,10 @@ func (p *postgres) DeleteStores(ctx context.Context, storeIds []string) error {
 			return err
 		}
 
+		if err := tx.Exec("DELETE FROM products WHERE store_id IN (?)", storeIds).Error; err != nil {
+			return err
+		}
+
 		return tx.Exec("DELETE FROM stores WHERE id IN (?)", storeIds).Error
 	})
 }


### PR DESCRIPTION
…o DeleteStores method

The DeleteStores method in the postgres repository was not deleting the associated products when deleting stores. This commit adds a new query to delete the products with matching store_ids before deleting the stores themselves. This ensures that all related data is properly cleaned up when deleting stores.